### PR TITLE
Improve responsive design

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,12 +15,10 @@ const handleDisconnect = () => {
 </script>
 
 <template>
-  <div class="grow flex flex-col">
-    <div class="relative grow flex flex-col mx-auto w-full overflow-hidden h-[0px]">
-      <div class="fixed inset-0 p-4 flex items-center justify-center bg-white">
-        <Starter v-if="!showChat" @start="handleStart" />
-        <Chat v-else @disconnect="handleDisconnect" />
-      </div>
+  <div class="min-h-screen flex flex-col">
+    <div class="flex-grow flex items-center justify-center p-4 bg-white">
+      <Starter v-if="!showChat" @start="handleStart" />
+      <Chat v-else @disconnect="handleDisconnect" />
     </div>
   </div>
 </template>

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -237,30 +237,40 @@ onUnmounted(() => {
 </script>
 
 <template>
-	<div class="h-full w-full">
-		<div class="w-full h-full overflow-y-auto">
-		<div v-for="(message, index) in messages" :key="index">
-			<template v-if="message.type === 'llm'">
-				<span v-if="message.emotion" class="">{{ message.text }}</span>
-			</template>
-			<template v-else-if="message.type === 'tts' && message.state === 'sentence_start'">
-				<div class="">{{ message.text }}</div>
-			</template>
-		</div>
-	</div>
-	<div class="fixed flex justify-center items-center w-full bottom-5">
-		<div class="flex flex-row justify-between items-center pr-2 rounded-lg bg-gray-100 focus:bg-gray-50 ring-2 ring-gray-200 focus:ring-gray-200">
-			<input v-model="inputMessage" @keyup.enter="sendMessage(inputMessage)" :placeholder="isConnected ? '输入消息' : '请稍等'"
-			class="p-3 focus:outline-none  disabled:cursor-not-allowed"
-			:disabled="!isConnected" />
-			<button @click="sendMessage(inputMessage)" :disabled="!isConnected" class="cursor-pointer bg-black text-white flex items-center justify-center w-8 h-8 rounded-full disabled:opacity-50 disabled:cursor-not-allowed">
-				<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-					<path d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z" />
-				</svg>
-			</button>
-		</div>
-	</div>
-	</div>
+  <div class="h-full w-full flex flex-col max-w-2xl mx-auto">
+    <div class="flex-1 overflow-y-auto p-4 space-y-2">
+      <div v-for="(message, index) in messages" :key="index">
+        <template v-if="message.type === 'llm'">
+          <span v-if="message.emotion">{{ message.text }}</span>
+        </template>
+        <template v-else-if="message.type === 'tts' && message.state === 'sentence_start'">
+          <div>{{ message.text }}</div>
+        </template>
+      </div>
+    </div>
+    <div class="sticky bottom-0 p-4 bg-white">
+      <div class="flex items-center gap-2 rounded-lg bg-gray-100 ring-2 ring-gray-200 focus-within:ring-black">
+        <input
+          v-model="inputMessage"
+          @keyup.enter="sendMessage(inputMessage)"
+          :placeholder="isConnected ? '输入消息' : '请稍等'"
+          class="flex-1 p-3 bg-transparent focus:outline-none disabled:cursor-not-allowed"
+          :disabled="!isConnected"
+        />
+        <button
+          @click="sendMessage(inputMessage)"
+          :disabled="!isConnected"
+          class="cursor-pointer bg-black text-white flex items-center justify-center w-8 h-8 rounded-full disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
 </template>
 
 <style></style>

--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -249,7 +249,9 @@ onUnmounted(() => {
       </div>
     </div>
     <div class="sticky bottom-0 p-4 bg-white">
-      <div class="flex items-center gap-2 rounded-lg bg-gray-100 ring-2 ring-gray-200 focus-within:ring-black">
+      <div
+        class="flex items-center gap-2 p-2 rounded-lg bg-gray-100 ring-2 ring-gray-200 focus-within:ring-black"
+      >
         <input
           v-model="inputMessage"
           @keyup.enter="sendMessage(inputMessage)"

--- a/src/components/Starter.vue
+++ b/src/components/Starter.vue
@@ -3,21 +3,32 @@ const emit = defineEmits(['start'])
 </script>
 
 <template>
-	<div style="will-change: auto; transform: none;">
-		<button @click="emit('start')"
-			class="cursor-pointer justify-center whitespace-nowrap rounded-md text-md font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-black text-white hover:bg-black/90 h-10 px-5 py-2 z-50 flex items-center gap-2">
-			<span>
-				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-					stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-					class="lucide lucide-phone size-4 opacity-50">
-					<path
-						d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z">
-					</path>
-				</svg>
-			</span>
-			<span>开始</span>
-		</button>
-	</div>
+  <div class="flex items-center justify-center w-full h-full">
+    <button
+      @click="emit('start')"
+      class="cursor-pointer flex items-center gap-2 rounded-md text-md font-medium bg-black text-white hover:bg-black/90 px-6 py-3"
+    >
+      <span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="lucide lucide-phone size-4 opacity-50"
+        >
+          <path
+            d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"
+          />
+        </svg>
+      </span>
+      <span>开始</span>
+    </button>
+  </div>
 </template>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary
- make root component structure flexible for various screen sizes
- center start button and adjust styles
- add responsive layout for Chat component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866888a97c48324a891f50bef9453bd